### PR TITLE
fixes an incorrect require

### DIFF
--- a/expect.underscore.js
+++ b/expect.underscore.js
@@ -6,7 +6,7 @@
 module.exports = {
     extend: function(expect, _) {
         if (typeof expect === 'undefined') {
-            expect = require('expectjs');
+            expect = require('expect.js');
         }
 
         if (typeof _ === 'undefined') {


### PR DESCRIPTION
The correct package name is "expect.js" and require uses "expectjs".
